### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/rpc.js
+++ b/lib/rpc.js
@@ -2,7 +2,7 @@ var comb = require("comb"),
     Promise = comb.Promise,
     when = comb.when,
     isHash = comb.isHash,
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     _Options = require("./_options");
 
 _Options.extend({

--- a/package.json
+++ b/package.json
@@ -1,50 +1,50 @@
 {
-    "name": "hare",
-    "version": "1.0.0",
-    "description": "Wrapper around amqp to make common patterns easier",
-    "keywords": [
-        "amqp",
-        "rabbit",
-        "rabbitmq",
-        "rpc",
-        "workerQueue",
-        "worker queue",
-        "worker",
-        "pubsub",
-        "pub-sub",
-        "pub",
-        "sub",
-        "routing",
-        "route",
-        "topic",
-        "topics",
-        "exchange",
-        "excahanges",
-        "queue",
-        "queues"
-    ],
-    "main": "index.js",
-    "scripts": {
-        "test": "it -r dot"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git@github.com:C2FO/hare.git"
-    },
-    "author": "Doug Martin",
-    "license": "MIT",
-    "dependencies": {
-        "amqp": "~0.2.0",
-        "comb": "~1.0.0",
-        "node-uuid": "^1.4.1"
-    },
-    "devDependencies": {
-        "grunt": "~0.4.1",
-        "it": "^1.0.1",
-        "grunt-it": "^1.0.0",
-        "grunt-contrib-jshint": "~0.5.4"
-    },
-    "engines": {
-        "node": ">= 4.0.0"
-    }
+  "name": "hare",
+  "version": "1.0.0",
+  "description": "Wrapper around amqp to make common patterns easier",
+  "keywords": [
+    "amqp",
+    "rabbit",
+    "rabbitmq",
+    "rpc",
+    "workerQueue",
+    "worker queue",
+    "worker",
+    "pubsub",
+    "pub-sub",
+    "pub",
+    "sub",
+    "routing",
+    "route",
+    "topic",
+    "topics",
+    "exchange",
+    "excahanges",
+    "queue",
+    "queues"
+  ],
+  "main": "index.js",
+  "scripts": {
+    "test": "it -r dot"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:C2FO/hare.git"
+  },
+  "author": "Doug Martin",
+  "license": "MIT",
+  "dependencies": {
+    "amqp": "~0.2.0",
+    "comb": "~1.0.0",
+    "uuid": "^3.0.0"
+  },
+  "devDependencies": {
+    "grunt": "~0.4.1",
+    "it": "^1.0.1",
+    "grunt-it": "^1.0.0",
+    "grunt-contrib-jshint": "~0.5.4"
+  },
+  "engines": {
+    "node": ">= 4.0.0"
+  }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.