### PR TITLE
Monkey patch reconnect due to big in node-amqp

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ function errorHandler(err) {
 }
 
 var connect = (function connectWrapper() {
-    var connectionPromise, connection, isConnected = false;
+    var connectionPromise, connection, isConnected = false, connectOpts = {};
 
     function ready() {
         isConnected = true;
@@ -41,16 +41,29 @@ var connect = (function connectWrapper() {
     function checkConnected() {
         if (!isConnected) {
             connectionError(new Error("Connection closed prematurely, please check your credentials"));
+        } else if (connectOpts.reconnect){
+            // monkey patch b/c node-amqp seems to be not maintained anymore based
+            // upon number of open issues, comments within issues stating it is no
+            // longer maintained and the age of open pull requests. node-amqp only
+            // publishes an error on the "end" event if the "ready" event has not
+            // yet been fired which means you probably have an issue authing with
+            // Rabbit. They should also have an else block and look to see if the
+            // socket is destroyed and if so, emit an error to which node-amqp
+            // will attempt to reconnect using the specified strategy.
+            connection.emit("error", new Error("Connection closed, attempting to reconnect"));
         }
     }
 
     return function connect(url, opts) {
         if (!connectionPromise) {
+            connectOpts = opts;
             connectionPromise = new Promise();
             connection = amqp.createConnection(url, opts);
             connection.once('ready', ready);
             connection.once('error', connectionError);
-            connection.once("close", checkConnected);
+            // use on instead of once for `close` so we can handle multiple
+            // subsequent disconnects.
+            connection.on("close", checkConnected);
         }
         return connectionPromise;
     };
@@ -150,7 +163,8 @@ var Hare = comb.define(_Options, {
 
     "static": {
         OPTIONS: ["defaultExchangeName", "reconnect", "reconnectBackoffStrategy",
-            "reconnectExponentialLimit", "reconnectExponentialLimit", "reconnectBackoffTime"]
+            "reconnectExponentialLimit", "reconnectExponentialLimit", "reconnectBackoffTime",
+            "heartbeatForceReconnect"]
     }
 
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hare",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Wrapper around amqp to make common patterns easier",
   "keywords": [
     "amqp",


### PR DESCRIPTION
Node-amqp has an open issue with heartbeats not reconnecting if they don't come back. When node-amqp loses connection, it emits an `end` which is then picked up in the end event listener. From there, it looks to see if the `ready` event was already fired, if it was not, the library then assumes you have an authentication issue and emits an error. The issue lies within here, it never looks to see if the socket was destroyed and then attempts to reconnect.

I have created a "fix" version that does not use the `options.reconnect` to verify you want to it to reconnect but its more a proof of concept at [e30ac3fabdd6379ff2d8e12c489d90371417e364](https://github.com/TechnotronicOz/node-amqp/commit/e30ac3fabdd6379ff2d8e12c489d90371417e364) 