### PR TITLE
Fix RPC hanging after amqp reconnect

### DIFF
--- a/lib/rpc.js
+++ b/lib/rpc.js
@@ -9,7 +9,9 @@ _Options.extend({
     instance: {
 
         constructor: function (rpcQueue, createQueue, createExchange) {
-            this.recieveQueue = createQueue().exclusive(true);
+            // specify a name for the reply queue so the name remains the same if amqp reconnects to rabbit
+            var recieveQueueName = rpcQueue.queueName + '-rpc-reply-' + uuid.v4();
+            this.recieveQueue = createQueue(recieveQueueName).exclusive(true);
             this.rpcQueue = rpcQueue;
             this.createExchange = createExchange;
             this.__requests = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hare",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Wrapper around amqp to make common patterns easier",
   "keywords": [
     "amqp",

--- a/test/hare.test.js
+++ b/test/hare.test.js
@@ -152,7 +152,8 @@ it.describe("hare", function (it) {
     it.describe(".rpc", function (it) {
 
         it.should("allow the creation of an rpc client", function () {
-            return hare().rpc("rpc_queue").handle(function () {
+            var rpc = hare().rpc("rpc_queue")
+            return rpc.handle(function () {
             }).chain(function () {
                 assert.equal(connection.getCallCount("queue"), 1);
                 assert.isTrue(connection.calledWith("queue", ["rpc_queue", {
@@ -164,6 +165,10 @@ it.describe("hare", function (it) {
                 assert.equal(queue.getCallCount("subscribe"), 1);
                 assert.equal(queue.getCallCount("bind"), 1);
                 assert.isTrue(queue.calledWith("bind", ["amq.direct", undefined]));
+                // the queue for replies should have the rpc queue name and a uuid for uniqueness
+                // e.g. rpc_queue-rpc-reply-DE13492E-337F-454C-8BA6-CFD18ED99E09
+                assert.isTrue(rpc.recieveQueue.queueName.startsWith("rpc_queue-rpc-reply-"));
+                assert.equal(rpc.recieveQueue.queueName.length, 56);
             });
         });
 


### PR DESCRIPTION
RPC queues stop processing RPC replies after a reconnect. This is because:
-  When an RPC queue is made, [hare creates a queue for replies, and does not specify a name](https://github.com/C2FO/hare/blob/6d18d70ec1397840c3a705f65ccda9b225fa44b7/lib/rpc.js#L12)
- When an RPC queue is made, [hare sets the routing key equal to the queue's name](https://github.com/C2FO/hare/blob/6d18d70ec1397840c3a705f65ccda9b225fa44b7/lib/queue.js#L37)
- When a queue name is blank, the rabbit broker will [generate a unique name for you](https://www.rabbitmq.com/queues.html#server-named-queues)
- When an RPC call is made, [hare stamps](https://github.com/C2FO/hare/blob/6d18d70ec1397840c3a705f65ccda9b225fa44b7/lib/rpc.js#L72) the amqp queue's name in the `replyTo` header. 
- When a queue is made, [amqp caches the routing key of the queue to use when reconnecting](https://github.com/postwait/node-amqp/blob/0bc3ffab79dd62f3579571579e3e52a4eb2df0c1/lib/queue.js#L251)
- On a reconnect, [amqp rebinds every queue, using the cached routing key](https://github.com/postwait/node-amqp/blob/0bc3ffab79dd62f3579571579e3e52a4eb2df0c1/lib/queue.js#L446)

So after a reconnect we're sending the new reply queue name in RPC messages in the replyTo header, but we're listening on a queue bound to the old queue name. 

To fix this we can specify a known name for our reply queues, so on reconnect we can create a queue with the original name and routing key.